### PR TITLE
Sort tags in sidebar

### DIFF
--- a/theme/templates/_sidebar.html
+++ b/theme/templates/_sidebar.html
@@ -39,7 +39,7 @@
             <h1>Tags</h1>
         </header>
         <div class="sidebar-tags">
-        {% for tag, article in tags %}
+        {% for tag, article in tags|sort %}
             <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
         {% endfor %}
         </div>


### PR DESCRIPTION
The tags in the sidebar are all over the place, which makes it a bit harder to find the tag you want than if they're alphabetised.