### PR TITLE
Add HTTPS for calls to Google Analytics and Google Fonts

### DIFF
--- a/theme/templates/_base.html
+++ b/theme/templates/_base.html
@@ -26,7 +26,7 @@
     <link href="{{ SITEURL }}/favicon.png" rel="icon">
     <link href="{{ SITEURL }}/theme/css/all.css" media="screen, projection" rel="stylesheet" type="text/css">
 
-    <link href="//fonts.googleapis.com/css?family=Lusitana:400,700|Merriweather:400,700,400italic,700italic|Source+Code+Pro:400,700|Love+Ya+Like+A+Sister&subset=latin,latin-ext"
+    <link href="https://fonts.googleapis.com/css?family=Lusitana:400,700|Merriweather:400,700,400italic,700italic|Source+Code+Pro:400,700|Love+Ya+Like+A+Sister&subset=latin,latin-ext"
         rel="stylesheet" type="text/css">
     {% if article and article.latex %}
         {{ article.latex }}
@@ -59,7 +59,7 @@
         <p>
             © 2011–2015 Eevee (Lexy Munroe)
             ·
-            <a rel="license" href="http://creativecommons.org/licenses/by/3.0/us/">
+            <a rel="license" href="https://creativecommons.org/licenses/by/3.0/us/">
                 <img
                     title="Licensed under Creative Commons Attribution 3.0 United States"
                     alt="Licensed under Creative Commons Attribution 3.0 United States"
@@ -80,8 +80,9 @@
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
         ga('create', '{{ GOOGLE_ANALYTICS }}', '{{ SITEURL.rpartition("://")[2] }}');
+        ga('set', 'forceSSL', true);
         ga('send', 'pageview');
     </script>
     {% endif %}


### PR DESCRIPTION
It's not perfect protection since the site is delivered over HTTP, but it's less exposure for your users, especially from network rules that target google-analytics.com and fonts.googleapis.com, two of the most high-value hostnames for attack.