### PR TITLE
Update Pelican link in base template

### DIFF
--- a/theme/templates/_base.html
+++ b/theme/templates/_base.html
@@ -71,7 +71,7 @@
             Backgrounds from <a href="https://www.toptal.com/designers/subtlepatterns/">Subtle Patterns</a>
         </p>
         <p>
-            Powered by <a href="http://docs.getpelican.com/en/3.3.0/">Pelican</a>
+            Powered by <a href="http://docs.getpelican.com">Pelican</a>
             ·
             <a href="https://github.com/eevee/eev.ee">Source code</a>
         </p>


### PR DESCRIPTION
Update the link to Pelican docs so it doesn't take you to an outdated version.

I'm not sure if you're actually running Pelican 3.3.0, but even if you do, I think the link should just go to the docs for the latest version.